### PR TITLE
Added custom patch to next-auth to load mongodb as mandatory dependency

### DIFF
--- a/next-auth.patch
+++ b/next-auth.patch
@@ -1,0 +1,12 @@
+diff -rwu node_modules/next-auth.orig/dist/adapters/typeorm/index.js node_modules/next-auth/dist/adapters/typeorm/index.js
+--- node_modules/next-auth.orig/dist/adapters/typeorm/index.js	2020-11-27 12:10:53.000000000 +0200
++++ node_modules/next-auth/dist/adapters/typeorm/index.js	2020-11-27 12:12:19.000000000 +0200
+@@ -115,7 +115,7 @@
+ 
+       if (config.type === 'mongodb') {
+         idKey = '_id';
+-        var mongodb = (0, _require_optional.default)('mongodb');
++        var mongodb = require('mongodb');
+         ObjectId = mongodb.ObjectId;
+       }
+ 


### PR DESCRIPTION
Uses webpack aliases and rewrites require_optional so it supports loading `mongodb` module. Works in AWS and in local production builds of NextJS and next-auth.
