### PR TITLE
Webpack alias to use instead of unsupported require_optional

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,1 +1,14 @@
-module.exports = { target: "serverless" };
+const path = require("path");
+
+module.exports = {
+  target: "serverless",
+
+  webpack: (config) => {
+    config.resolve.alias = {
+      ...config.resolve.alias,
+      require_optional: path.resolve(__dirname, "require-not-optional"),
+    };
+
+    return config;
+  },
+};

--- a/require-not-optional/README.md
+++ b/require-not-optional/README.md
@@ -1,0 +1,3 @@
+# require_optional replacemenet
+
+This replaces require_optional in next-auth with one which loads `mongodb` module.

--- a/require-not-optional/index.js
+++ b/require-not-optional/index.js
@@ -1,0 +1,11 @@
+const mongodb = require("mongodb");
+
+module.exports = (module) => {
+  if (module === "mongodb") {
+    return mongodb;
+  } else {
+    var e = new Error("Cannot find module '" + module + "'");
+    e.code = "MODULE_NOT_FOUND";
+    throw e;
+  }
+};

--- a/require-not-optional/package.json
+++ b/require-not-optional/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "require-not-optional",
+  "version": "0.1.1",
+  "private": false,
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC"
+}


### PR DESCRIPTION
Uses webpack aliases and rewrites require_optional so it supports loading `mongodb` module. Works in AWS and in local production builds of NextJS and next-auth.
